### PR TITLE
注释掉了导致云函数只读错误的两行代码

### DIFF
--- a/utils/USER.py
+++ b/utils/USER.py
@@ -29,8 +29,8 @@ def get_cookie_from_login(student_id: str, password: str, cookie_file_path=COOKI
     if r.status_code == 200:
         if r.json()['e'] == 0:
             print("登录成功")
-            with open(cookie_file_path, 'wb') as f:
-                pickle.dump(r.cookies, f)
+            #with open(cookie_file_path, 'wb') as f:
+                #pickle.dump(r.cookies, f)
             return r.cookies
         else:
             print(r.json()['m'])


### PR DESCRIPTION
我找不到Issue在哪填了，我按照步骤在腾讯云函数上一步一步来，得到了以下报错：
`{"errorCode":1,"errorMessage":"user code exception caught","stackTrace":"Traceback (most recent call last):\n  File \"/var/user/index.py\", line 14, in index\n    _cookie = USER.login()\n  File \"/var/user/utils/USER.py\", line 58, in login\n    _cookies = load_cookie_from_file(COOKIE_FILE_NAME)\n  File \"/var/user/utils/USER.py\", line 47, in load_cookie_from_file\n    return pickle.load(f)\nEOFError: Ran out of input"}`
我把USER里写入cookies文件的相关代码注释了（因为俺不会py），就能跑了
这个pull request你直接拒绝掉就好，可以在README里面写一下云函数怎么处理
感谢dalao